### PR TITLE
DFRobot compatible values

### DIFF
--- a/components/sen0322/sen0322.cpp
+++ b/components/sen0322/sen0322.cpp
@@ -11,6 +11,7 @@ static const char *const TAG = "sen0322";
 static const uint8_t SEN0322_COLLECT_PHASE = 0x01;
 static const uint8_t SEN0322_JUDGE_PHASE = 0x02;
 static const uint8_t SEN0322_OXYGEN_DATA = 0x03;
+static const uint8_t SEN0322_GET_KEY_REGISTER = 0x0A;
 
 void SEN0322Sensor::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SEN0322...");
@@ -26,6 +27,15 @@ void SEN0322Sensor::setup() {
   ESP_LOGCONFIG(TAG, "SEN0322 setup complete");
 }
 
+void SEN0322Sensor::readFlash() {
+  uint8_t value = 0;
+  value = this->read_byte(SEN0322_GET_KEY_REGISTER).value_or(0);
+  ESP_LOGD(TAG, "Got flash value: 0x%02X", value);
+  
+  if (value == 0) { key = 20.9 / 120.0; }
+  else { key = (float)value / 1000.0; }
+}
+
 void SEN0322Sensor::dump_config() {
   ESP_LOGCONFIG(TAG, "SEN0322 Oxygen Sensor:");
   LOG_I2C_DEVICE(this);
@@ -39,33 +49,35 @@ void SEN0322Sensor::dump_config() {
 
 void SEN0322Sensor::update() {
   ESP_LOGV(TAG, "Updating SEN0322 sensor...");
-  
+  readFlash();
   // Send command to read oxygen concentration
-  if (!this->write_byte(SEN0322_OXYGEN_DATA, 0x00)) {
-    ESP_LOGE(TAG, "Failed to send oxygen data command");
-    this->status_set_warning();
-    return;
-  }
+  //if (!this->write_byte(SEN0322_OXYGEN_DATA, 0x00)) {
+  //  ESP_LOGE(TAG, "Failed to send oxygen data command");
+  //  this->status_set_warning();
+  //  return;
+  //}
   
   // Wait for sensor to process
-  delay(50);
+  //delay(50);
   
   // Read 3 bytes of data
   uint8_t data[3];
-  if (!this->read_bytes_raw(data, 3)) {
+  if (!this->read_bytes(SEN0322_OXYGEN_DATA, data, 3)) {
     ESP_LOGE(TAG, "Failed to read oxygen data");
     this->status_set_warning();
     return;
   }
+
+  ESP_LOGD(TAG, "Read 3 bytes: [0] = 0x%02X, [1] = 0x%02X, [2] = 0x%02X", data[0], data[1], data[2]);
   
   // Parse oxygen concentration with little-endian byte order
   // SEN0322 uses reversed byte order: data[1] = high byte, data[0] = low byte
-  uint16_t raw_oxygen = (data[1] << 8) | data[0];
-  float oxygen_concentration = raw_oxygen * 0.01f;
+  // uint16_t raw_oxygen = (data[1] << 8) | data[0];
+  float oxygen_concentration = (key * (((float)data[0]) + ((float)data[1] / 10.0) + ((float)data[2] / 100.0)));
   
   // Validate reading (oxygen should be between 0-30% for safety margin)
   if (oxygen_concentration < 0.0f || oxygen_concentration > 30.0f) {
-    ESP_LOGW(TAG, "Invalid oxygen reading: %.2f%% (raw: 0x%04X)", oxygen_concentration, raw_oxygen);
+    ESP_LOGW(TAG, "Invalid oxygen reading: %.2f%%", oxygen_concentration);
     this->status_set_warning();
     return;
   }

--- a/components/sen0322/sen0322.h
+++ b/components/sen0322/sen0322.h
@@ -15,6 +15,8 @@ class SEN0322Sensor : public PollingComponent, public i2c::I2CDevice, public sen
   float get_setup_priority() const override;
 
  protected:
+  float key;
+  void readFlash();
   // Additional methods can be added here if needed for advanced functionality
 };
 

--- a/components/sen0322/sen0322.h
+++ b/components/sen0322/sen0322.h
@@ -15,7 +15,7 @@ class SEN0322Sensor : public PollingComponent, public i2c::I2CDevice, public sen
   float get_setup_priority() const override;
 
  protected:
-  float key;
+  float calibrated_value_;
   void readFlash();
   // Additional methods can be added here if needed for advanced functionality
 };

--- a/components/sen0322/sensor.py
+++ b/components/sen0322/sensor.py
@@ -9,7 +9,7 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["i2c"]
-CODEOWNERS = ["@makbart1980"]  # Zmień na swoją nazwę GitHub
+CODEOWNERS = ["@makbart1980", "@SergeyZh"]  # Zmień na swoją nazwę GitHub
 
 sen0322_ns = cg.esphome_ns.namespace("sen0322")
 SEN0322Sensor = sen0322_ns.class_("SEN0322Sensor", cg.PollingComponent, i2c.I2CDevice)


### PR DESCRIPTION
I've adapted the [DFRobot library](https://github.com/DFRobot/DFRobot_OxygenSensor/tree/master/src) to work with your code. Now I'm getting the same values in ESPHome as I did on the Arduino platform. We can make further improvements, such as calibrations and so on, but it already works as expected. See the picture below.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/cfcbb450-ccaf-481b-b8dc-5a43a91c2742" />
